### PR TITLE
fix: update verify process

### DIFF
--- a/model/utils.py
+++ b/model/utils.py
@@ -392,7 +392,7 @@ def evaluate_posterior(
                         # if has_nan:
                         #     print(1)
                         adjustflag = True
-        if adjustflag:
+        if adjustflag and accept_length != candidates.shape[1]:
             sample_p = gtp
         else:
             gt_logits = logits[best_candidate, accept_length - 1]


### PR DESCRIPTION
I think the verification process needs another condition. According to the prove in [SpecInfer](https://arxiv.org/pdf/2305.09781.pdf), when all candidates in one draft candidate path are accepted, we need to sample the `sample_token` from the `logits` of the last accepted node. Here, you still sample from the `gtp` and the last accepted token is also sampled from `gtp`, which may cause repetition in the output. Here is what I got from your example.

![image](https://github.com/SafeAILab/EAGLE/assets/37681002/24ef90ea-f89f-45b5-8306-14fc28043cb5)

Please correct me if I misunderstood anything!
