### PR TITLE
bug fix: hidden_states nan

### DIFF
--- a/eagle/model/modeling_llama_kv.py
+++ b/eagle/model/modeling_llama_kv.py
@@ -724,12 +724,26 @@ class LlamaDecoderLayer(nn.Module):
         )
         hidden_states = residual + hidden_states
 
+        if hidden_states.dtype == torch.float16:
+            clamp_value = torch.where(
+                torch.isinf(hidden_states).any(),
+                torch.finfo(hidden_states.dtype).max - 1000,
+                torch.finfo(hidden_states.dtype).max,
+            )
+            hidden_states = torch.clamp(hidden_states, min=-clamp_value, max=clamp_value)
         # Fully Connected
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
         hidden_states = self.mlp(hidden_states)
         hidden_states = residual + hidden_states
 
+        if hidden_states.dtype == torch.float16:
+            clamp_value = torch.where(
+                torch.isinf(hidden_states).any(),
+                torch.finfo(hidden_states.dtype).max - 1000,
+                torch.finfo(hidden_states.dtype).max,
+            )
+            hidden_states = torch.clamp(hidden_states, min=-clamp_value, max=clamp_value)
         outputs = (hidden_states,)
 
         if output_attentions:


### PR DESCRIPTION
BUG DESCRIPTION:
'NaN' occasionally occurs as below:
![image](https://github.com/SafeAILab/EAGLE/assets/139844877/08832999-f404-4b78-8007-57c2fd03d01d)

The bug can be reproduced:
base_model: [Llama-2-7b-chat-hf](https://huggingface.co/NousResearch/Llama-2-7b-chat-hf)
ea_model: [EAGLE-llama2-chat-7B](https://huggingface.co/yuhuili/EAGLE-llama2-chat-7B)
ea_model.py:265
`import random`
`seed = 18`
`random.seed(seed)`
`torch.random.manual_seed(seed)`
webui input: What is deep learning
#45 
#23 
The bug occurs in step 192. The fundamental reason is the overflow of 'down_proj' in the 30th layer leading to the output of softmax 'nan'
![image](https://github.com/SafeAILab/EAGLE/assets/139844877/3ace2693-7c73-4602-b12e-6e37ef636ab0)
![image](https://github.com/SafeAILab/EAGLE/assets/139844877/b47f0962-8904-4fb7-9a78-7832b1443d86)
Therefore, I add two clamps after attention layers and mlp layers following the [T5](https://github.com/huggingface/transformers/blob/main/src/transformers/models/t5/modeling_t5.py#L702) in transformers.

I think the reason why the bug occurs is the inputs of the base_model are unusual, not like normal sentences a model is trained on.