### PR TITLE
eagl3/eagle switch, updates requirements

### DIFF
--- a/eagle/evaluation/gen_ea_answer_llama3chat.py
+++ b/eagle/evaluation/gen_ea_answer_llama3chat.py
@@ -111,7 +111,8 @@ def get_model_answers(
         torch_dtype=torch.float16,
         low_cpu_mem_usage=True,
         # load_in_8bit=True,
-        device_map="auto"
+        device_map="auto",
+        use_eagle3=args.use_eagle3,
     )
 
     tokenizer = model.get_tokenizer()
@@ -403,8 +404,15 @@ if __name__ == "__main__":
         type=str,
         default="mc_sim_7b_63",
     )
+    parser.add_argument(
+        "--use_eagle3",
+        action="store_true"
+    )
 
     args = parser.parse_args()
+
+    for k,v in vars(args).items():
+        print(f"{k}={v}")
 
     args.model_id = args.model_id + "-temperature-" + str(args.temperature)
     if args.num_gpus_total // args.num_gpus_per_model > 1:

--- a/eagle/evaluation/gen_ea_answer_vicuna.py
+++ b/eagle/evaluation/gen_ea_answer_vicuna.py
@@ -109,7 +109,8 @@ def get_model_answers(
         torch_dtype=torch.float16,
         low_cpu_mem_usage=True,
         # load_in_8bit=True,
-        device_map="auto"
+        device_map="auto",
+        use_eagle3=args.use_eagle3,
     )
 
     tokenizer = model.get_tokenizer()
@@ -368,7 +369,15 @@ if __name__ == "__main__":
         default="mc_sim_7b_63",
     )
 
+    parser.add_argument(
+        "--use-eagle3",
+        action="store_true"
+    )
+
     args = parser.parse_args()
+
+    for k,v in vars(args).items():
+        print(f"{k}={v}")
 
     args.model_id = args.model_id + "-temperature-" + str(args.temperature)
     if args.num_gpus_total // args.num_gpus_per_model > 1:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-torch==2.0.1
-transformers==4.46.2
-accelerate==0.21.0
+torch==2.6.0
+transformers>=4.47.0
+accelerate==0.26.0
 fschat==0.2.31
 gradio==3.50.2
 openai==0.28.0


### PR DESCRIPTION
This PR adds explicit `use_eagle3` flag propagation for more convenient switching between Eagle/Eagle3 models. Updates requirements for `torch` and `transformers`.
