### PR TITLE
fix bug in top_p sample

### DIFF
--- a/eagle/model/utils.py
+++ b/eagle/model/utils.py
@@ -410,7 +410,12 @@ def evaluate_posterior(
             sample_p = gtp
         else:
             gt_logits = logits[best_candidate, accept_length - 1]
-            gt_logits = logits_processor(None, gt_logits)
+            if logits_processor is not None:
+                if gt_logits.dim() == 1:
+                    vocab_size = gt_logits.size(0)
+                    gt_logits = gt_logits.view(1, vocab_size)
+                gt_logits = logits_processor(None, gt_logits)
+                gt_logits = gt_logits.view(-1)
             sample_p = torch.softmax(gt_logits, dim=0)
         return torch.tensor(best_candidate), accept_length - 1, sample_p
 


### PR DESCRIPTION
The function evaluate_posterior() in eagle/model/utils.py raises an exception when using mixed sampling parameters:
```output_ids = model.eagenerate(input_ids, temperature=0.1, top_p=0.9, max_length=500)```
Error deatils
```IndexError: Dimension out of range (expected to be in range of [-1, 0], but got 1)```
This occus at:
```gt_logits = logits_processor(None, gt_logits)  ```
The TopP processor requires a 2D tensor with shape [batch_size, vocab_size] , However, gt_logits is a 1D tensor with shape [vocab_size] when extracted from logits[best_candidate, accept_length - 1].

