### PR TITLE
fix: the problem of loading local model path and downloading from hug…

### DIFF
--- a/eagle/model/cnets1.py
+++ b/eagle/model/cnets1.py
@@ -28,6 +28,7 @@ import torch.utils.checkpoint
 from torch import nn
 
 from transformers.activations import ACT2FN
+from huggingface_hub import hf_hub_download
 
 
 try:
@@ -481,20 +482,32 @@ class Model(nn.Module):
             from safetensors import safe_open
             import json
             try:
-                with open(os.path.join(path, "model.safetensors.index.json"), "r") as f:
+                index_json_path = os.path.join(path, "model.safetensors.index.json")
+                if not os.path.exists(index_json_path):
+                    index_json_path = hf_hub_download(path, "model.safetensors.index.json")
+                with open(index_json_path, "r") as f:
                     index_json = json.loads(f.read())
                     emb_path = index_json["weight_map"]["model.embed_tokens.weight"]
-                with safe_open(os.path.join(path, emb_path),
+                local_emb_path = os.path.join(path, emb_path)
+                if not os.path.exists(local_emb_path):
+                    local_emb_path = hf_hub_download(path, emb_path)
+                with safe_open(local_emb_path,
                                framework="pt",
                                device="cpu") as f:
                     tensor_slice = f.get_slice("model.embed_tokens.weight")
                     vocab_size, hidden_dim = tensor_slice.get_shape()
                     tensor = tensor_slice[:, :hidden_dim].float()
             except:
-                with open(os.path.join(path, "pytorch_model.bin.index.json"), "r") as f:
+                index_json_path = os.path.join(path, "pytorch_model.bin.index.json")
+                if not os.path.exists(index_json_path):
+                    index_json_path = hf_hub_download(path, "pytorch_model.bin.index.json")
+                with open(index_json_path, "r") as f:
                     index_json = json.loads(f.read())
                     emb_path = index_json["weight_map"]["model.embed_tokens.weight"]
-                weights = torch.load(os.path.join(path, emb_path))
+                local_emb_path = os.path.join(path, emb_path)
+                if not os.path.exists(local_emb_path):
+                    local_emb_path = hf_hub_download(path, emb_path)
+                weights = torch.load(local_emb_path)
                 tensor = weights["model.embed_tokens.weight"].float()
             self.embed_tokens.weight.data = tensor
 


### PR DESCRIPTION
I found that the code can only be used by specifying the path. If the path is not specified, some files will not be found. 
Now it supports downloading the model directly from huggingface and automatically downloading it to the huggingface cache directory without specifying the local path.
just like: 
```
python -m eagle.evaluation.gen_ea_answer_llama3chat --ea-model-path yuhuili/EAGLE3-LLaMA3.1-Instruct-8B --base-model-path meta-llama/Llama-3.1-8B-Instruct --use_eagle3
```