### PR TITLE
support: Run EAGLE on AMD ROCm

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ EAGLE has been merged in the following mainstream LLM serving frameworks (listed
 - <a href="https://github.com/intel-analytics/ipex-llm/pull/11104">Intel® LLM Library for PyTorch</a>
 - <a href="https://llm.mlc.ai/docs/deploy/rest.html">MLC-LLM</a>
 - <a href="https://github.com/NVIDIA/TensorRT-LLM/tree/main/examples/eagle">NVIDIA TensorRT-LLM</a>
-- <a href="[https://docs.sglang.ai/backend/speculative_decoding.html](https://rocm.docs.amd.com/en/latest/)">AMD ROCm</a>
+- <a href="https://rocm.docs.amd.com/en/latest/">AMD ROCm</a>
 - <a href="https://docs.sglang.ai/backend/speculative_decoding.html">SGLang</a>
 - <a href="https://github.com/vllm-project/vllm/pull/16937">vLLM</a>
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ EAGLE has been merged in the following mainstream LLM serving frameworks (listed
 - <a href="https://github.com/intel-analytics/ipex-llm/pull/11104">Intel® LLM Library for PyTorch</a>
 - <a href="https://llm.mlc.ai/docs/deploy/rest.html">MLC-LLM</a>
 - <a href="https://github.com/NVIDIA/TensorRT-LLM/tree/main/examples/eagle">NVIDIA TensorRT-LLM</a>
+- <a href="[https://docs.sglang.ai/backend/speculative_decoding.html](https://rocm.docs.amd.com/en/latest/)">AMD ROCm</a>
 - <a href="https://docs.sglang.ai/backend/speculative_decoding.html">SGLang</a>
 - <a href="https://github.com/vllm-project/vllm/pull/16937">vLLM</a>
 

--- a/requirements-rocm.txt
+++ b/requirements-rocm.txt
@@ -1,0 +1,11 @@
+--extra-index-url https://download.pytorch.org/whl/rocm6.3
+torch==2.6.0
+transformers>=4.47.0
+accelerate==0.26.0
+fschat==0.2.31
+gradio==3.50.2
+openai==0.28.0
+anthropic==0.5.0
+sentencepiece==0.1.99
+protobuf==3.19.0
+wandb


### PR DESCRIPTION
- Modify README.md for indicating that EAGLE can be run smoothly on AMD ROCm platform.
- Add up a requirements-rocm.txt for switching torch version to torch rocm.