### PR TITLE
增加了MiniCPM4的eagle3权重，并且将MiniCPM4的在sglang中的适配同步提交了

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ pip install -r requirements.txt
 | [Qwen/Qwen3-8B](https://huggingface.co/Qwen/Qwen3-8B)    | [AngelSlim/Qwen3-8B_eagle3](https://huggingface.co/AngelSlim/Qwen3-8B_eagle3) | [Qwen/Qwen3-30B-A3B](https://huggingface.co/Qwen/Qwen3-30B-A3B)    | [AngelSlim/Qwen3-a3B_eagle3](https://huggingface.co/AngelSlim/Qwen3-a3B_eagle3) |
 | [Qwen/Qwen3-4B](https://huggingface.co/Qwen/Qwen3-4B)    | [AngelSlim/Qwen3-4B_eagle3](https://huggingface.co/AngelSlim/Qwen3-4B_eagle3) | [Qwen/Qwen3-32B](https://huggingface.co/Qwen/Qwen3-32B)    | [AngelSlim/Qwen3-32B_eagle3](https://huggingface.co/AngelSlim/Qwen3-32B_eagle3) |
 | [Qwen/Qwen3-1.7B](https://huggingface.co/Qwen/Qwen3-1.7B)    | [AngelSlim/Qwen3-1.7B_eagle3](https://huggingface.co/AngelSlim/Qwen3-1.7B_eagle3) | [Qwen/Qwen3-14B](https://huggingface.co/Qwen/Qwen3-14B)    | [AngelSlim/Qwen3-14B_eagle3](https://huggingface.co/AngelSlim/Qwen3-14B_eagle3) |
-
+| [openbmb/MiniCPM4-8B](https://huggingface.co/openbmb/MiniCPM4-8B)    | [linglingdan/Eagle3_for_MiniCPM4](https://modelscope.cn/models/linglingdan/Eagle3_for_MiniCPM4) | |  |
 
 ## EAGLE Weights
 


### PR DESCRIPTION
- 训练数据从 ShareGPT 和 UltraChat 混合起来的 30w 条数据中随机采样 15w 条作为训练草稿模型的数据，使用UltraChat 的 sft 数据集作为测试集（2.5w条左右）
<img width="1941" height="1013" alt="image" src="https://github.com/user-attachments/assets/fb014659-30a2-4edd-8022-a1d0683350a2" />

以下是sglang下测试的结果
<img width="2315" height="1095" alt="image" src="https://github.com/user-attachments/assets/7ecf4862-4efe-41b7-a1f0-d868ea7aa1b6" />
