### PR TITLE
Update requirements.txt for modeling_qwen3_kv.py 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 torch==2.6.0
-transformers>=4.47.0
+transformers==4.53.0
 accelerate==0.26.0
 fschat==0.2.31
 gradio==3.50.2


### PR DESCRIPTION
This pull request addresses issue: https://github.com/SafeAILab/EAGLE/issues/278 regarding to commit https://github.com/SafeAILab/EAGLE/commit/e0d1b454ed4c2ead0aa1ef17fee1958b15965609;

Where an import error with `from transformers.utils import LossKwargs` arise from modeling_qwen3_kv.py [commit e0d1b45]("add support for qwen3 with eagle3") now requires a specific version of transformers to be compatible, specifical version transformers-4.53.0;

Either transformers-4.52.0 or transformers-4.54.0 will have a modified API for the location of LossKwargs in transformers.util and inccur import error;