### PR TITLE
fix: remove wrong attn mask update

### DIFF
--- a/eagle/traineagle3/cnets.py
+++ b/eagle/traineagle3/cnets.py
@@ -862,10 +862,6 @@ class Model(nn.Module):
                 input_ids = padding(input_ids, left=False)
                 target = padding(target, left=False)
                 loss_mask = padding(loss_mask, left=False)
-                ind=torch.arange(seq_length,device=attention_mask.device)
-                ind0=ind[idx:]
-                ind1=ind[:seq_length-idx]
-                attention_mask[:,:,ind0,ind1]=torch.finfo(attention_mask.dtype).min
 
 
 


### PR DESCRIPTION
In the TTT process, subsequent token generation should always be able to see the KV cache from the current position and all previous positions when the first token was generated. Please carefully check this process.

However, I was surprised that this bug only caused a slight performance loss. I used SpecForge for training, and after fixing this bug, the average acceptance length on Spec-Bench improved from 3.332 to 3.366.

And here is the tfevents of the training process.
[tfevents.zip](https://github.com/user-attachments/files/22354607/tfevents.zip)
