### PR TITLE
fix: typo and dict access via dot notation bug

### DIFF
--- a/eagle/traineagle3/cnets.py
+++ b/eagle/traineagle3/cnets.py
@@ -489,7 +489,7 @@ class Model(nn.Module):
         else:
             dschf = None
         self.midlayer = LlamaDecoderLayeremb(config)
-        self.gradient_checkpointing = self.train_config.gradient_checkpointing
+        self.gradient_checkpointing = self.train_config["gradient_checkpointing"]
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
         self.hidden_size = config.hidden_size
@@ -588,7 +588,7 @@ class Model(nn.Module):
                     # When construct draft model vocab, 
                     # filter out samples which is longer than max_len,
                     # instead of truncating them.
-                    if len(input_ids) > self.train_config.max_len:
+                    if len(input_ids) > self.train_config["max_len"]:
                         continue
                     loss_mask = torch.ones_like(input_ids)
                     # print(i)

--- a/eagle/traineagle3/main.py
+++ b/eagle/traineagle3/main.py
@@ -23,7 +23,7 @@ train_config = {
     "num_workers": 2,
     "max_len": 2048,
     "config_path": "config.json",
-    "gradient_checkpoint": True
+    "gradient_checkpointing": True
 }
 
 from safetensors import safe_open


### PR DESCRIPTION
There is a typo in training config.