### PR TITLE
fix: exclude last position from loss_mask after target shift

### DIFF
--- a/eagle/traineagle3/cnets.py
+++ b/eagle/traineagle3/cnets.py
@@ -725,6 +725,7 @@ class Model(nn.Module):
 
         if target is not None:
             target = target.to(device)
+            loss_mask[..., -1] = 0  # Exclude last position (now contains padding)
             loss_mask = loss_mask[..., None]
             loss_mask = loss_mask.to(device)
 


### PR DESCRIPTION
Fixes #317

target and input_ids are shifted left by one position in dataprepare() 
via padding(..., left=False), which puts a zero-padding value in the 
last position instead of a real next-token value. loss_mask wasn't 
adjusted to match, so training was computing loss on that final, 
invalid position.

This adds one line to exclude the last position from the mask after 
the shift, as originally suggested in the issue.

Verified with a small repro (numpy, mirrors the actual padding() logic):

before fix
target: [202 203 204 205   0]
loss_mask: [1 1 1 1 1]     <- last position still marked for training

after fix
target: [202 203 204 205   0]
loss_mask: [1 1 1 1 0]     <- correctly excluded