### PR TITLE
fix: respect explicit config.head_dim in cnets attention

### DIFF
--- a/eagle/model/cnets.py
+++ b/eagle/model/cnets.py
@@ -196,16 +196,13 @@ class LlamaAttention(nn.Module):
         self.config = config
         self.hidden_size = config.hidden_size
         self.num_heads = config.num_attention_heads
-        self.head_dim = self.hidden_size // self.num_heads
+        if hasattr(config, "head_dim") and config.head_dim is not None:
+            self.head_dim = config.head_dim
+        else:
+            self.head_dim = self.hidden_size // self.num_heads
         self.num_key_value_heads = config.num_key_value_heads
         self.num_key_value_groups = self.num_heads // self.num_key_value_heads
         self.max_position_embeddings = config.max_position_embeddings
-
-        if (self.head_dim * self.num_heads) != self.hidden_size:
-            raise ValueError(
-                f"hidden_size must be divisible by num_heads (got `hidden_size`: {self.hidden_size}"
-                f" and `num_heads`: {self.num_heads})."
-            )
         self.q_proj = nn.Linear(self.hidden_size * 2, self.num_heads * self.head_dim, bias=False)
         self.k_proj = nn.Linear(self.hidden_size * 2, self.num_key_value_heads * self.head_dim, bias=False)
         self.v_proj = nn.Linear(self.hidden_size * 2, self.num_key_value_heads * self.head_dim, bias=False)
@@ -318,7 +315,7 @@ class LlamaAttention(nn.Module):
             )
 
         attn_output = attn_output.transpose(1, 2).contiguous()
-        attn_output = attn_output.reshape(bsz, q_len, self.hidden_size)
+        attn_output = attn_output.reshape(bsz, q_len, self.num_heads * self.head_dim)
 
         if self.config.pretraining_tp > 1:
             attn_output = attn_output.split(self.hidden_size // self.config.pretraining_tp, dim=2)


### PR DESCRIPTION
Fixes #315

Credit to @gcy-hw95, who diagnosed this and tested the fix in #315 — this PR just submits it properly since it never got merged.

This PR fixes the `head_dim` handling in `eagle/model/cnets.py`.

Previously, `LlamaAttention` always computed:

```python
self.head_dim = self.hidden_size // self.num_heads
```

That works for standard Llama-style configs, but it does not hold for some Qwen3 configs where `head_dim` is explicitly defined. For example, Qwen3-4B has `hidden_size=2560` and `num_attention_heads=32`, which gives `80` using the old formula, but the actual `head_dim` is `128`.

Because of this mismatch, loading Qwen3 checkpoints can fail with shape mismatch errors.

This PR changes the code to:

* use `config.head_dim` when it exists
* fall back to `hidden_size // num_heads` when `config.head_dim` is not present
* remove the assertion that required `hidden_size == num_heads * head_dim`
* update the attention output reshape to use `num_heads * head_dim` instead of assuming it is equal to `hidden_size`

This follows the same general pattern already used in `modeling_qwen3_kv.py`.

One note: I left the `pretraining_tp > 1` path unchanged because it seems separate from this issue and was not part of the original fix discussed in #315.
